### PR TITLE
feat: react-hook-form register 등록 위한 input 구조 변경 및 공통 스타일 수정

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
     directory: '/'
     open-pull-requests-limit: 10
     schedule:
-      interval: "never"
+      interval: 'never'

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b",
   "dependencies": {
+    "@hookform/resolvers": "^3.9.0",
     "@t3-oss/env-nextjs": "0.9.2",
     "@tanstack/react-query": "^5.37.1",
     "@tanstack/react-query-devtools": "^5.37.1",
@@ -35,6 +36,7 @@
     "next-auth": "^4.24.7",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-hook-form": "^7.53.0",
     "tailwind-merge": "2.2.2",
     "zod": "3.22.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2861,10 +2861,16 @@ packages:
       '@testing-library/dom': '>=7.21.4'
 
   '@toast-ui/editor@3.2.2':
-    resolution: {integrity: sha512-ASX7LFjN2ZYQJrwmkUajPs7DRr9FsM1+RQ82CfTO0Y5ZXorBk1VZS4C2Dpxinx9kl55V4F8/A2h2QF4QMDtRbA==}
+    resolution:
+      {
+        integrity: sha512-ASX7LFjN2ZYQJrwmkUajPs7DRr9FsM1+RQ82CfTO0Y5ZXorBk1VZS4C2Dpxinx9kl55V4F8/A2h2QF4QMDtRbA==
+      }
 
   '@toast-ui/react-editor@3.2.3':
-    resolution: {integrity: sha512-86QdgiOkBeSwRBEUWRKsTpnm6yu5j9HNJ3EfQN8EGcd7kI8k8AhExXyUJ3NNgNTzN7FfSKMw+1VaCDDC+aZ3dw==}
+    resolution:
+      {
+        integrity: sha512-86QdgiOkBeSwRBEUWRKsTpnm6yu5j9HNJ3EfQN8EGcd7kI8k8AhExXyUJ3NNgNTzN7FfSKMw+1VaCDDC+aZ3dw==
+      }
     peerDependencies:
       react: ^17.0.1
 
@@ -5261,7 +5267,10 @@ packages:
     engines: { node: '>= 4' }
 
   dompurify@2.5.6:
-    resolution: {integrity: sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==}
+    resolution:
+      {
+        integrity: sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==
+      }
 
   domutils@2.8.0:
     resolution:
@@ -8582,7 +8591,10 @@ packages:
     engines: { node: '>=18' }
 
   orderedmap@2.1.1:
-    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+    resolution:
+      {
+        integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==
+      }
 
   os-browserify@0.3.0:
     resolution:
@@ -9251,28 +9263,52 @@ packages:
       }
 
   prosemirror-commands@1.6.0:
-    resolution: {integrity: sha512-xn1U/g36OqXn2tn5nGmvnnimAj/g1pUx2ypJJIe8WkVX83WyJVC5LTARaxZa2AtQRwntu9Jc5zXs9gL9svp/mg==}
+    resolution:
+      {
+        integrity: sha512-xn1U/g36OqXn2tn5nGmvnnimAj/g1pUx2ypJJIe8WkVX83WyJVC5LTARaxZa2AtQRwntu9Jc5zXs9gL9svp/mg==
+      }
 
   prosemirror-history@1.4.1:
-    resolution: {integrity: sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==}
+    resolution:
+      {
+        integrity: sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==
+      }
 
   prosemirror-inputrules@1.4.0:
-    resolution: {integrity: sha512-6ygpPRuTJ2lcOXs9JkefieMst63wVJBgHZGl5QOytN7oSZs3Co/BYbc3Yx9zm9H37Bxw8kVzCnDsihsVsL4yEg==}
+    resolution:
+      {
+        integrity: sha512-6ygpPRuTJ2lcOXs9JkefieMst63wVJBgHZGl5QOytN7oSZs3Co/BYbc3Yx9zm9H37Bxw8kVzCnDsihsVsL4yEg==
+      }
 
   prosemirror-keymap@1.2.2:
-    resolution: {integrity: sha512-EAlXoksqC6Vbocqc0GtzCruZEzYgrn+iiGnNjsJsH4mrnIGex4qbLdWWNza3AW5W36ZRrlBID0eM6bdKH4OStQ==}
+    resolution:
+      {
+        integrity: sha512-EAlXoksqC6Vbocqc0GtzCruZEzYgrn+iiGnNjsJsH4mrnIGex4qbLdWWNza3AW5W36ZRrlBID0eM6bdKH4OStQ==
+      }
 
   prosemirror-model@1.22.2:
-    resolution: {integrity: sha512-I4lS7HHIW47D0Xv/gWmi4iUWcQIDYaJKd8Hk4+lcSps+553FlQrhmxtItpEvTr75iAruhzVShVp6WUwsT6Boww==}
+    resolution:
+      {
+        integrity: sha512-I4lS7HHIW47D0Xv/gWmi4iUWcQIDYaJKd8Hk4+lcSps+553FlQrhmxtItpEvTr75iAruhzVShVp6WUwsT6Boww==
+      }
 
   prosemirror-state@1.4.3:
-    resolution: {integrity: sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==}
+    resolution:
+      {
+        integrity: sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==
+      }
 
   prosemirror-transform@1.9.0:
-    resolution: {integrity: sha512-5UXkr1LIRx3jmpXXNKDhv8OyAOeLTGuXNwdVfg8x27uASna/wQkr9p6fD3eupGOi4PLJfbezxTyi/7fSJypXHg==}
+    resolution:
+      {
+        integrity: sha512-5UXkr1LIRx3jmpXXNKDhv8OyAOeLTGuXNwdVfg8x27uASna/wQkr9p6fD3eupGOi4PLJfbezxTyi/7fSJypXHg==
+      }
 
   prosemirror-view@1.33.9:
-    resolution: {integrity: sha512-xV1A0Vz9cIcEnwmMhKKFAOkfIp8XmJRnaZoPqNXrPS7EK5n11Ov8V76KhR0RsfQd/SIzmWY+bg+M44A2Lx/Nnw==}
+    resolution:
+      {
+        integrity: sha512-xV1A0Vz9cIcEnwmMhKKFAOkfIp8XmJRnaZoPqNXrPS7EK5n11Ov8V76KhR0RsfQd/SIzmWY+bg+M44A2Lx/Nnw==
+      }
 
   proxy-addr@2.0.7:
     resolution:
@@ -9808,7 +9844,10 @@ packages:
       }
 
   rope-sequence@1.3.4:
-    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
+    resolution:
+      {
+        integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==
+      }
 
   run-async@3.0.0:
     resolution:
@@ -11119,7 +11158,10 @@ packages:
       }
 
   w3c-keyname@2.2.8:
-    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+    resolution:
+      {
+        integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==
+      }
 
   w3c-xmlserializer@4.0.0:
     resolution:

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -1,31 +1,49 @@
 'use client';
 
 import React from 'react';
+import { FieldValues, UseFormRegister } from 'react-hook-form';
 
-interface InputProps {
+interface InputProps<T extends FieldValues> {
   className?: string;
   placeholder?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   type?: string;
+  register?: UseFormRegister<T>;
+  name?: string;
 }
 
-const SInput = ({ className = '', placeholder, value, onChange, type = 'text' }: InputProps) => {
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (onChange) {
-      onChange(e);
-    }
-  };
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+const SInput = React.forwardRef<HTMLInputElement, InputProps<any>>(
+  ({ className = '', placeholder, value, onChange, name, register, type = 'text' }, ref) => {
+    const {
+      onChange: registerOnChange,
+      ref: registerRef,
+      ...restRegister
+    } = register && name ? register(name) : { ref: undefined, onChange: undefined };
 
-  return (
-    <input
-      type={type}
-      className={`px-4 py-2 border border-slate-300 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-tree-300 ${className}`}
-      placeholder={placeholder}
-      value={value}
-      onChange={handleChange}
-    />
-  );
-};
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      [registerOnChange, onChange].forEach((fn) => {
+        if (fn) {
+          fn(e);
+        }
+      });
+    };
+
+    return (
+      <input
+        type={type}
+        ref={registerRef || ref}
+        className={`w-full p-3 border border-slate-300 rounded-base bg-white focus:outline-none focus:ring-2 focus:ring-tree-300 ${className}`}
+        placeholder={placeholder}
+        value={value}
+        onChange={handleChange}
+        {...restRegister}
+      />
+    );
+  }
+);
+
+SInput.displayName = 'SInput';
 
 export default SInput;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 html {
-    font-size: 62.5%; /* 1rem = 10px (기본 16px * 0.625 = 10px) */
+  font-size: 62.5%; /* 1rem = 10px (기본 16px * 0.625 = 10px) */
 }


### PR DESCRIPTION
hook-form 을 사용하는 와중에
register를 등록해야 해서 SInput에 register를 등록할 수 있게 구성하였습니다.

유효성 체크랑 공통 progress 진척도 체크를 위해 scheme로 한 번에 관리할 수 있게끔 도와주는 react-hook-form 라이브러리를 사용했습니다.

현재 SInput 내에 register 등록하지 않으면 기존 SInput과 동일하게 사용할 수 있습니다

그리고, 공통 스타일이 제대로 반영이 되어 있지 않아 수정했습니다.