### PR TITLE
feat: auth-provider 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,6 +21,7 @@ const cls = (...classnames: string[]) => {
   return classnames.join(' ');
 };
 
+import { AuthProvider } from '@/components/providers/AuthProvider';
 import { ReactQueryProvider } from '@/components/providers/ReactQuery';
 import SessionWrapper from '@/components/SessionWrapper';
 import { MainLayout } from '@/components/templates/MainLayout';
@@ -34,14 +35,16 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <SessionWrapper>
       <html lang="kr">
-        <body className={cls(pretendard.className, montserrat.variable)} suppressHydrationWarning>
-          <div id="modal" />
-          <ReactQueryProvider>
-            <MainLayout>
-              <main>{children}</main>
-            </MainLayout>
-          </ReactQueryProvider>
-        </body>
+        <AuthProvider>
+          <body className={cls(pretendard.className, montserrat.variable)} suppressHydrationWarning>
+            <div id="modal" />
+            <ReactQueryProvider>
+              <MainLayout>
+                <main>{children}</main>
+              </MainLayout>
+            </ReactQueryProvider>
+          </body>
+        </AuthProvider>
       </html>
     </SessionWrapper>
   );

--- a/src/components/providers/AuthProvider/index.tsx
+++ b/src/components/providers/AuthProvider/index.tsx
@@ -2,6 +2,7 @@
 
 import withModal from '@/enhancers/WithModal';
 import React, { createContext, useState, ReactNode, useContext } from 'react';
+import { Optional } from 'types/common';
 
 import SignInModal from '@/components/account/SignInModal';
 
@@ -10,7 +11,7 @@ interface AuthContextType {
   setToggleLogin: (value: boolean) => void;
 }
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
+const AuthContext = createContext<Optional<AuthContextType>>(undefined);
 
 const SignWithModal = withModal(SignInModal);
 

--- a/src/components/providers/AuthProvider/index.tsx
+++ b/src/components/providers/AuthProvider/index.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import withModal from '@/enhancers/WithModal';
+import React, { createContext, useState, ReactNode, useContext } from 'react';
+
+import SignInModal from '@/components/account/SignInModal';
+
+interface AuthContextType {
+  toggleLogin: boolean;
+  setToggleLogin: (value: boolean) => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+const SignWithModal = withModal(SignInModal);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [toggleLogin, setToggleLogin] = useState(false);
+
+  const onClickCloseModal = () => {
+    setToggleLogin(false);
+  };
+
+  return (
+    <AuthContext.Provider value={{ toggleLogin, setToggleLogin }}>
+      {children}
+      <SignWithModal isVisible={toggleLogin} onClickClose={onClickCloseModal} />
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuthContext() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('Error at AuthContext');
+  }
+
+  return context;
+}

--- a/src/service/auth/queries.ts
+++ b/src/service/auth/queries.ts
@@ -34,7 +34,7 @@ const AuthQueryOptions = {
   })
 };
 
-const isLoggedIn = async (cookies?: () => ReadonlyRequestCookies): Promise<boolean> => {
+export const isLoggedIn = async (cookies?: () => ReadonlyRequestCookies): Promise<boolean> => {
   const accessToken = await getCookie(COOKIE_KEY.ACCESS_TOKEN, { cookies });
 
   return !!accessToken;

--- a/src/utils/withAuthCallback.ts
+++ b/src/utils/withAuthCallback.ts
@@ -1,7 +1,8 @@
 'use client';
 
 import { isLoggedIn } from '@/service/auth/queries';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { Nullable } from 'types/common';
 
 import { useAuthContext } from '@/components/providers/AuthProvider';
 
@@ -9,7 +10,7 @@ import { getCookie } from './cookie';
 
 function useWithAuthCallback(callback: () => void) {
   const { setToggleLogin } = useAuthContext();
-  const [isSignIn, setIsSignIn] = useState<boolean | null>(null);
+  const [isSignIn, setIsSignIn] = useState<Nullable<boolean>>(null);
 
   useEffect(() => {
     let mounted = true;
@@ -31,7 +32,7 @@ function useWithAuthCallback(callback: () => void) {
     };
   }, []);
 
-  const handleAuthCallback = () => {
+  const handleAuthCallback = useCallback(() => {
     if (isSignIn === null) {
       return;
     }
@@ -43,7 +44,7 @@ function useWithAuthCallback(callback: () => void) {
     }
 
     callback();
-  };
+  }, [isSignIn, setToggleLogin, callback]);
 
   return handleAuthCallback;
 }

--- a/src/utils/withAuthCallback.ts
+++ b/src/utils/withAuthCallback.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { isLoggedIn } from '@/service/auth/queries';
+import { useState, useEffect } from 'react';
+
+import { useAuthContext } from '@/components/providers/AuthProvider';
+
+import { getCookie } from './cookie';
+
+function useWithAuthCallback(callback: () => void) {
+  const { setToggleLogin } = useAuthContext();
+  const [isSignIn, setIsSignIn] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const checkLoginStatus = async () => {
+      const loggedInFromAuth = await isLoggedIn();
+      const hasRefreshToken = Boolean(getCookie('refreshToken'));
+      const isAuthenticated = loggedInFromAuth || hasRefreshToken;
+
+      if (mounted) {
+        setIsSignIn(isAuthenticated);
+      }
+    };
+
+    checkLoginStatus();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleAuthCallback = () => {
+    if (isSignIn === null) {
+      return;
+    }
+
+    if (!isSignIn) {
+      setToggleLogin(true);
+
+      return;
+    }
+
+    callback();
+  };
+
+  return handleAuthCallback;
+}
+
+export default useWithAuthCallback;


### PR DESCRIPTION
로그인 유무 + refreshToken도 없으면 로그인 모달을 띄우게끔 해주는 Provider랑 훅 하나 만들었습니다.

401받고 response interceptor에서도 이걸 활용하면 좋을 것 같은데 한 번 고민해보겠습니다.

예를들어
useWithAuthCallback(token 쏘는 api 콜) -> 요런식으로 쓰면 미리 판단하게끔 설정했습니다.